### PR TITLE
Add trading app example service and CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,14 @@ print(response)
 ```
 Please find `examples` folder to check for more endpoints.
 
+### Trading App Example
+
+The [`examples/trading_app`](examples/trading_app) folder contains a reference implementation of a
+FastAPI service that can run on a Google Cloud VM. It exposes account balances, position data and
+order placement capabilities for the Aster exchange. A companion command line client makes it easy
+to retrieve that information from a local workstation and forward order instructions back to the
+VM. See the example README for setup and usage details.
+
 ### Base URL
 `https://fapi.asterdex.com`
 

--- a/examples/trading_app/README.md
+++ b/examples/trading_app/README.md
@@ -1,0 +1,61 @@
+# Trading App Example
+
+This example demonstrates how to expose basic trading operations for the Aster exchange through a FastAPI service that can run on a Google Cloud VM. A lightweight Python client is also included so that a local machine can retrieve account information and forward order instructions to the remote service.
+
+## Features
+
+* Retrieve account balances and current positions from the VM.
+* Determine whether there is an open position for a symbol and automatically create one if none exists.
+* Submit manual orders from the local client and forward them to the VM for execution.
+
+## Components
+
+* `server.py` – FastAPI application meant to run on the Google Cloud VM. It proxies Aster API requests.
+* `client.py` – Command line client for a local workstation. It communicates with the remote server over HTTP.
+* `requirements.txt` – Additional dependencies needed for the example (FastAPI, Uvicorn, HTTPX).
+
+## Prerequisites
+
+1. Install the base project requirements as described in the repository README.
+2. Install the example specific dependencies:
+
+   ```bash
+   pip install -r examples/trading_app/requirements.txt
+   ```
+
+3. Create an `.env` file on the VM next to `server.py` or export the following environment variables:
+
+   * `ASTER_API_KEY`
+   * `ASTER_API_SECRET`
+
+## Running the Server on Google Cloud VM
+
+```bash
+export ASTER_API_KEY="<your_api_key>"
+export ASTER_API_SECRET="<your_api_secret>"
+uvicorn examples.trading_app.server:app --host 0.0.0.0 --port 8000
+```
+
+Make sure that port `8000` (or the port of your choice) is allowed through the VM firewall so that your local machine can connect to the service.
+
+## Using the Local Client
+
+From your local machine, configure the server URL (replace `vm-public-ip`):
+
+```bash
+python examples/trading_app/client.py --server http://vm-public-ip:8000 account
+```
+
+### Supported Client Commands
+
+* `account` – Fetch balances and open positions.
+* `ensure-position` – Ensure there is an open position for a symbol, opening one if necessary.
+* `order` – Submit a custom order payload.
+
+Run `python examples/trading_app/client.py --help` for full usage details.
+
+## Security Notes
+
+* The example uses plain HTTP for simplicity. Consider enabling HTTPS (via an HTTPS load balancer or a reverse proxy such as Nginx) before exposing it to the public internet.
+* Secure access to the VM using firewall rules or a VPN. The Aster API credentials grant trading access and must be protected.
+

--- a/examples/trading_app/client.py
+++ b/examples/trading_app/client.py
@@ -1,0 +1,147 @@
+"""Command line client for interacting with the trading service."""
+from __future__ import annotations
+
+import argparse
+import json
+from typing import Any, Dict, List, Optional
+
+import httpx
+
+
+DEFAULT_SERVER = "http://localhost:8000"
+
+
+def parse_extra_arguments(extra: List[str]) -> Dict[str, Any]:
+    parsed: Dict[str, Any] = {}
+    for argument in extra:
+        if "=" not in argument:
+            raise ValueError(f"Extra argument must be in key=value format: {argument}")
+        key, value = argument.split("=", 1)
+        parsed[key] = value
+    return parsed
+
+
+def request(method: str, url: str, *, json_payload: Optional[Dict[str, Any]] = None) -> Any:
+    response = httpx.request(method, url, json=json_payload, timeout=30.0)
+    response.raise_for_status()
+    if response.content:
+        return response.json()
+    return None
+
+
+def handle_account(args: argparse.Namespace) -> None:
+    url = f"{args.server}/account"
+    data = request("GET", url)
+    print(json.dumps(data, indent=2, sort_keys=True))
+
+
+def handle_order(args: argparse.Namespace) -> None:
+    url = f"{args.server}/orders"
+    payload: Dict[str, Any] = {
+        "symbol": args.symbol,
+        "side": args.side,
+        "type": args.type,
+        "quantity": args.quantity,
+    }
+    if args.price is not None:
+        payload["price"] = args.price
+    if args.time_in_force:
+        payload["timeInForce"] = args.time_in_force
+    if args.reduce_only is not None:
+        payload["reduceOnly"] = args.reduce_only
+    if args.client_order_id:
+        payload["newClientOrderId"] = args.client_order_id
+    if args.recv_window is not None:
+        payload["recvWindow"] = args.recv_window
+    payload.update(parse_extra_arguments(args.extra))
+
+    data = request("POST", url, json_payload=payload)
+    print(json.dumps(data, indent=2, sort_keys=True))
+
+
+def handle_ensure_position(args: argparse.Namespace) -> None:
+    url = f"{args.server}/ensure-position"
+    payload: Dict[str, Any] = {
+        "symbol": args.symbol,
+        "side": args.side,
+        "type": args.type,
+        "quantity": args.quantity,
+    }
+    if args.price is not None:
+        payload["price"] = args.price
+    if args.time_in_force:
+        payload["timeInForce"] = args.time_in_force
+    if args.recv_window is not None:
+        payload["recvWindow"] = args.recv_window
+    payload.update(parse_extra_arguments(args.extra))
+
+    data = request("POST", url, json_payload=payload)
+    print(json.dumps(data, indent=2, sort_keys=True))
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Client for the Aster trading gateway")
+    parser.add_argument("--server", default=DEFAULT_SERVER, help="Base URL of the trading server")
+
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    account_parser = subparsers.add_parser("account", help="Fetch balances and open positions")
+    account_parser.set_defaults(func=handle_account)
+
+    ensure_parser = subparsers.add_parser(
+        "ensure-position", help="Ensure an open position exists; place an order if not"
+    )
+    ensure_parser.add_argument("symbol", help="Trading symbol, e.g. BTCUSDT")
+    ensure_parser.add_argument("side", help="Order side (BUY or SELL)")
+    ensure_parser.add_argument("quantity", type=float, help="Order quantity")
+    ensure_parser.add_argument("--type", default="MARKET", help="Order type (default: MARKET)")
+    ensure_parser.add_argument("--price", type=float, help="Limit price")
+    ensure_parser.add_argument("--time-in-force", dest="time_in_force", help="Time in force policy")
+    ensure_parser.add_argument("--recv-window", dest="recv_window", type=int, help="Custom recvWindow")
+    ensure_parser.add_argument(
+        "--extra",
+        nargs="*",
+        default=[],
+        help="Additional key=value pairs forwarded to the API",
+    )
+    ensure_parser.set_defaults(func=handle_ensure_position)
+
+    order_parser = subparsers.add_parser("order", help="Submit a raw order payload")
+    order_parser.add_argument("symbol", help="Trading symbol, e.g. BTCUSDT")
+    order_parser.add_argument("side", help="Order side (BUY or SELL)")
+    order_parser.add_argument("type", help="Order type, e.g. MARKET or LIMIT")
+    order_parser.add_argument("quantity", type=float, help="Order quantity")
+    order_parser.add_argument("--price", type=float, help="Limit price")
+    order_parser.add_argument("--time-in-force", dest="time_in_force", help="Time in force policy")
+    order_parser.add_argument("--reduce-only", dest="reduce_only", action="store_true")
+    order_parser.add_argument("--no-reduce-only", dest="reduce_only", action="store_false")
+    order_parser.set_defaults(reduce_only=None)
+    order_parser.add_argument("--client-order-id", dest="client_order_id", help="Client order identifier")
+    order_parser.add_argument("--recv-window", dest="recv_window", type=int, help="Custom recvWindow")
+    order_parser.add_argument(
+        "--extra",
+        nargs="*",
+        default=[],
+        help="Additional key=value pairs forwarded to the API",
+    )
+    order_parser.set_defaults(func=handle_order)
+
+    return parser
+
+
+def main() -> None:
+    parser = build_parser()
+    args = parser.parse_args()
+    try:
+        args.func(args)
+    except ValueError as error:
+        print(error)
+        raise SystemExit(1) from error
+    except httpx.HTTPError as error:
+        print(f"Request failed: {error}")
+        raise SystemExit(1) from error
+
+
+if __name__ == "__main__":
+    main()
+

--- a/examples/trading_app/requirements.txt
+++ b/examples/trading_app/requirements.txt
@@ -1,0 +1,4 @@
+fastapi>=0.110
+uvicorn[standard]>=0.23
+httpx>=0.24
+python-dotenv>=1.0

--- a/examples/trading_app/server.py
+++ b/examples/trading_app/server.py
@@ -1,0 +1,148 @@
+"""FastAPI trading service for running on a Google Cloud VM."""
+from __future__ import annotations
+
+import os
+from functools import lru_cache
+from typing import Any, Dict, List, Optional
+
+from dotenv import load_dotenv
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+
+from aster.error import ClientError
+from aster.rest_api import Client
+
+load_dotenv()
+
+
+def _env(name: str) -> str:
+    value = os.getenv(name)
+    if not value:
+        raise RuntimeError(f"Environment variable {name} is required to start the trading service.")
+    return value
+
+
+@lru_cache()
+def get_client() -> Client:
+    """Return a cached API client configured with environment credentials."""
+    return Client(key=_env("ASTER_API_KEY"), secret=_env("ASTER_API_SECRET"))
+
+
+class AccountOverview(BaseModel):
+    balances: List[Dict[str, Any]]
+    positions: List[Dict[str, Any]]
+    has_open_positions: bool
+
+
+class OrderRequest(BaseModel):
+    symbol: str
+    side: str
+    type: str = "MARKET"
+    quantity: float
+    price: Optional[float] = None
+    timeInForce: Optional[str] = None
+    reduceOnly: Optional[bool] = None
+    newClientOrderId: Optional[str] = None
+    recvWindow: Optional[int] = None
+
+    class Config:
+        extra = "allow"
+
+    def to_api_params(self) -> Dict[str, Any]:
+        return self.dict(exclude_none=True)
+
+
+class EnsurePositionRequest(OrderRequest):
+    """Ensure that a position exists for the requested symbol."""
+
+
+class EnsurePositionResponse(BaseModel):
+    has_position: bool
+    position: Optional[Dict[str, Any]] = None
+    order_placed: bool = False
+    order_response: Optional[Dict[str, Any]] = None
+
+
+app = FastAPI(title="Aster Trading Gateway", version="1.0.0")
+
+
+def _has_open_position(positions: List[Dict[str, Any]], symbol: Optional[str] = None) -> Optional[Dict[str, Any]]:
+    for position in positions:
+        if symbol and position.get("symbol") != symbol:
+            continue
+        try:
+            quantity = float(position.get("positionAmt", 0))
+        except (TypeError, ValueError):
+            quantity = 0
+        if abs(quantity) > 0:
+            return position
+    return None
+
+
+def _handle_client_error(error: ClientError) -> HTTPException:
+    detail = {
+        "code": error.error_code,
+        "message": error.error_message,
+        "status_code": error.status_code,
+        "header": error.header,
+    }
+    return HTTPException(status_code=error.status_code or 400, detail=detail)
+
+
+@app.get("/account", response_model=AccountOverview)
+def account_overview() -> AccountOverview:
+    client = get_client()
+    try:
+        balances = client.balance()
+        positions = client.get_position_risk()
+    except ClientError as error:
+        raise _handle_client_error(error) from error
+
+    open_position = _has_open_position(positions)
+    return AccountOverview(
+        balances=balances,
+        positions=positions,
+        has_open_positions=open_position is not None,
+    )
+
+
+@app.post("/orders")
+def create_order(order: OrderRequest) -> Dict[str, Any]:
+    client = get_client()
+    payload = order.to_api_params()
+    try:
+        response = client.new_order(**payload)
+    except ClientError as error:
+        raise _handle_client_error(error) from error
+    return {"order": response}
+
+
+@app.post("/ensure-position", response_model=EnsurePositionResponse)
+def ensure_position(request: EnsurePositionRequest) -> EnsurePositionResponse:
+    client = get_client()
+    try:
+        positions = client.get_position_risk()
+    except ClientError as error:
+        raise _handle_client_error(error) from error
+
+    position = _has_open_position(positions, symbol=request.symbol)
+    if position:
+        return EnsurePositionResponse(has_position=True, position=position)
+
+    payload = request.to_api_params()
+    try:
+        order_response = client.new_order(**payload)
+    except ClientError as error:
+        raise _handle_client_error(error) from error
+
+    return EnsurePositionResponse(
+        has_position=False,
+        order_placed=True,
+        order_response=order_response,
+    )
+
+
+@app.get("/ping")
+def ping() -> Dict[str, str]:
+    return {"status": "ok"}
+


### PR DESCRIPTION
## Summary
- add a FastAPI trading gateway example that surfaces balances, positions, and order placement endpoints
- provide a companion CLI client and documentation for running the service on a Google Cloud VM
- document the new example in the project README

## Testing
- python -m compileall examples/trading_app

------
https://chatgpt.com/codex/tasks/task_e_68df970ce6808329b794418179758f5f