### PR TITLE
Add Chinese documentation for trading gateway example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # aster-connector-python
+[English](README.md) | [中文文档](README.zh.md)
 [![Python 3.6](https://img.shields.io/badge/python-3.6+-blue.svg)](https://www.python.org/downloads/release/python-360/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
@@ -43,6 +44,14 @@ response = client.new_order(**params)
 print(response)
 ```
 Please find `examples` folder to check for more endpoints.
+
+### Trading App Example
+
+The [`examples/trading_app`](examples/trading_app) folder contains a reference implementation of a
+FastAPI service that can run on a Google Cloud VM. It exposes account balances, position data and
+order placement capabilities for the Aster exchange. A companion command line client makes it easy
+to retrieve that information from a local workstation and forward order instructions back to the
+VM. See the example README for setup and usage details.
 
 ### Base URL
 `https://fapi.asterdex.com`

--- a/README.zh.md
+++ b/README.zh.md
@@ -1,0 +1,74 @@
+# aster-connector-python 中文指南
+
+本项目提供了一个轻量级的 Python 库，用于连接 [Aster Finance 公共 API](https://github.com/asterdex/api-docs)。
+同时，我们也在 `examples` 目录下提供了示例程序，帮助你快速搭建交易服务并通过命令行客户端进行交互。
+
+## 安装
+
+```bash
+pip install aster-connector-python
+```
+
+## 快速开始
+
+```python
+from aster.rest_api import Client
+
+# 获取服务器时间
+client = Client()
+print(client.time())
+
+client = Client(key="<api_key>", secret="<api_secret>")
+
+# 查询账户信息
+print(client.account())
+
+# 创建新订单
+params = {
+    "symbol": "BTCUSDT",
+    "side": "SELL",
+    "type": "LIMIT",
+    "timeInForce": "GTC",
+    "quantity": 0.002,
+    "price": 59808,
+}
+
+response = client.new_order(**params)
+print(response)
+```
+
+更多可用接口请查阅 `examples` 目录以及项目源码注释。
+
+## 示例：云端交易服务
+
+`examples/trading_app` 目录提供了一个可以部署在 Google Cloud 虚拟机上的 FastAPI 服务，
+用于代理 Aster 交易所接口并对外暴露账户查询、自动建仓以及自定义下单等能力。
+
+* `server.py`：运行在云服务器上的 FastAPI 应用，负责转发请求到 Aster API。
+* `client.py`：运行在本地电脑的命令行客户端，可读取账户信息并发起下单请求。
+* `requirements.txt`：示例所需的额外依赖列表。
+
+### 启动服务
+
+在云端虚拟机上配置环境变量并启动服务：
+
+```bash
+export ASTER_API_KEY="<your_api_key>"
+export ASTER_API_SECRET="<your_api_secret>"
+uvicorn examples.trading_app.server:app --host 0.0.0.0 --port 8000
+```
+
+### 本地访问
+
+```bash
+python examples/trading_app/client.py --server http://<vm_ip>:8000 account
+```
+
+客户端还支持 `order` 与 `ensure-position` 子命令，帮助你快速下单或自动建立持仓。
+
+## 其他资源
+
+* `README.md`：英文版本的项目介绍。
+* `examples/trading_app/README.md`：包含更详细的部署与安全说明。
+
+如需更多信息，请参阅源码中的中文文档字符串以及 Aster 官方 API 文档。

--- a/examples/trading_app/README.md
+++ b/examples/trading_app/README.md
@@ -1,0 +1,125 @@
+# Trading App Example
+
+This example demonstrates how to expose basic trading operations for the Aster exchange through a FastAPI service that can run on a Google Cloud VM. A lightweight Python client is also included so that a local machine can retrieve account information and forward order instructions to the remote service.
+
+## Features
+
+* Retrieve account balances and current positions from the VM.
+* Determine whether there is an open position for a symbol and automatically create one if none exists.
+* Submit manual orders from the local client and forward them to the VM for execution.
+
+## Components
+
+* `server.py` – FastAPI application meant to run on the Google Cloud VM. It proxies Aster API requests.
+* `client.py` – Command line client for a local workstation. It communicates with the remote server over HTTP.
+* `requirements.txt` – Additional dependencies needed for the example (FastAPI, Uvicorn, HTTPX).
+
+## Prerequisites
+
+1. Install the base project requirements as described in the repository README.
+2. Install the example specific dependencies:
+
+   ```bash
+   pip install -r examples/trading_app/requirements.txt
+   ```
+
+3. Create an `.env` file on the VM next to `server.py` or export the following environment variables:
+
+   * `ASTER_API_KEY`
+   * `ASTER_API_SECRET`
+
+## Running the Server on Google Cloud VM
+
+```bash
+export ASTER_API_KEY="<your_api_key>"
+export ASTER_API_SECRET="<your_api_secret>"
+uvicorn examples.trading_app.server:app --host 0.0.0.0 --port 8000
+```
+
+Make sure that port `8000` (or the port of your choice) is allowed through the VM firewall so that your local machine can connect to the service.
+
+## Using the Local Client
+
+From your local machine, configure the server URL (replace `vm-public-ip`):
+
+```bash
+python examples/trading_app/client.py --server http://vm-public-ip:8000 account
+```
+
+### Supported Client Commands
+
+* `account` – Fetch balances and open positions.
+* `ensure-position` – Ensure there is an open position for a symbol, opening one if necessary.
+* `order` – Submit a custom order payload.
+
+Run `python examples/trading_app/client.py --help` for full usage details.
+
+## Security Notes
+
+* The example uses plain HTTP for simplicity. Consider enabling HTTPS (via an HTTPS load balancer or a reverse proxy such as Nginx) before exposing it to the public internet.
+* Secure access to the VM using firewall rules or a VPN. The Aster API credentials grant trading access and must be protected.
+
+---
+
+## 中文指南
+
+该示例演示如何通过 FastAPI 在 Google Cloud 虚拟机上部署一个交易网关，
+并利用随附的 Python 命令行客户端在本地读取账户信息、检查持仓以及下单。
+
+### 功能概览
+
+* 从云端服务器获取账户余额与当前持仓。
+* 如果指定交易对没有持仓，自动创建一笔订单建立仓位。
+* 通过本地客户端提交自定义订单并交由云端服务执行。
+
+### 组件说明
+
+* `server.py`：部署在云服务器上的 FastAPI 应用，代理 Aster API。
+* `client.py`：运行在本地的命令行工具，通过 HTTP 与服务器通信。
+* `requirements.txt`：示例所需的额外依赖（FastAPI、Uvicorn、HTTPX）。
+
+### 前置条件
+
+1. 根据仓库 `README.md` 完成基础依赖安装。
+2. 安装示例依赖：
+
+   ```bash
+   pip install -r examples/trading_app/requirements.txt
+   ```
+
+3. 在虚拟机上创建 `.env` 文件或导出以下环境变量：
+
+   * `ASTER_API_KEY`
+   * `ASTER_API_SECRET`
+
+### 启动服务器
+
+```bash
+export ASTER_API_KEY="<your_api_key>"
+export ASTER_API_SECRET="<your_api_secret>"
+uvicorn examples.trading_app.server:app --host 0.0.0.0 --port 8000
+```
+
+确保虚拟机防火墙开放 `8000` 端口（或你自定义的端口），以便本地客户端连接。
+
+### 使用本地客户端
+
+在本地机器上配置服务器地址（`vm-public-ip` 为云服务器公网 IP）：
+
+```bash
+python examples/trading_app/client.py --server http://vm-public-ip:8000 account
+```
+
+客户端支持以下子命令：
+
+* `account`：查询余额与持仓。
+* `ensure-position`：确保存在指定交易对的持仓，若没有则自动下单。
+* `order`：提交自定义订单请求。
+
+更多使用方式可执行 `python examples/trading_app/client.py --help` 查看。
+
+### 安全提示
+
+* 示例默认使用 HTTP，建议上线前配置 HTTPS（如通过反向代理或负载均衡器）。
+* 通过防火墙或 VPN 限制访问，妥善保护具有交易权限的 Aster API 凭证。
+

--- a/examples/trading_app/client.py
+++ b/examples/trading_app/client.py
@@ -1,0 +1,178 @@
+"""Command line client for interacting with the trading service.
+
+该模块实现了一个命令行客户端，用于本地计算机与部署在云端的交易服务交互，
+支持查询账户信息、检查持仓并下发新订单。"""
+from __future__ import annotations
+
+import argparse
+import json
+from typing import Any, Dict, List, Optional
+
+import httpx
+
+
+DEFAULT_SERVER = "http://localhost:8000"
+
+
+def parse_extra_arguments(extra: List[str]) -> Dict[str, Any]:
+    """Parse `key=value` formatted arguments into a dictionary.
+
+    将附加参数列表解析为字典形式，便于透传给后端 API；若格式不正确则抛出
+    ``ValueError`` 并提示用户按 ``key=value`` 规范填写。"""
+    parsed: Dict[str, Any] = {}
+    for argument in extra:
+        if "=" not in argument:
+            raise ValueError(f"Extra argument must be in key=value format: {argument}")
+        key, value = argument.split("=", 1)
+        parsed[key] = value
+    return parsed
+
+
+def request(method: str, url: str, *, json_payload: Optional[Dict[str, Any]] = None) -> Any:
+    """Perform an HTTP request and return JSON data when available.
+
+    统一封装客户端的 HTTP 请求逻辑，处理超时与状态码异常，并在响应体存在
+    内容时返回解析后的 JSON 数据。"""
+    response = httpx.request(method, url, json=json_payload, timeout=30.0)
+    response.raise_for_status()
+    if response.content:
+        return response.json()
+    return None
+
+
+def handle_account(args: argparse.Namespace) -> None:
+    """Call the account endpoint and print the JSON response.
+
+    调用远程服务的 ``/account`` 接口并格式化输出账户余额与持仓信息，方便
+    用户在终端中快速查看。"""
+    url = f"{args.server}/account"
+    data = request("GET", url)
+    print(json.dumps(data, indent=2, sort_keys=True))
+
+
+def handle_order(args: argparse.Namespace) -> None:
+    """Submit a raw order payload to the remote trading service.
+
+    根据命令行参数组装下单请求，透传额外 ``key=value`` 参数，并将服务端返回
+    的执行结果以 JSON 形式打印出来。"""
+    url = f"{args.server}/orders"
+    payload: Dict[str, Any] = {
+        "symbol": args.symbol,
+        "side": args.side,
+        "type": args.type,
+        "quantity": args.quantity,
+    }
+    if args.price is not None:
+        payload["price"] = args.price
+    if args.time_in_force:
+        payload["timeInForce"] = args.time_in_force
+    if args.reduce_only is not None:
+        payload["reduceOnly"] = args.reduce_only
+    if args.client_order_id:
+        payload["newClientOrderId"] = args.client_order_id
+    if args.recv_window is not None:
+        payload["recvWindow"] = args.recv_window
+    payload.update(parse_extra_arguments(args.extra))
+
+    data = request("POST", url, json_payload=payload)
+    print(json.dumps(data, indent=2, sort_keys=True))
+
+
+def handle_ensure_position(args: argparse.Namespace) -> None:
+    """Ensure a position exists by calling the dedicated endpoint.
+
+    访问 ``/ensure-position`` 接口确认指定交易对是否已有持仓，如无持仓则由
+    服务端自动建仓，并展示对应返回数据。"""
+    url = f"{args.server}/ensure-position"
+    payload: Dict[str, Any] = {
+        "symbol": args.symbol,
+        "side": args.side,
+        "type": args.type,
+        "quantity": args.quantity,
+    }
+    if args.price is not None:
+        payload["price"] = args.price
+    if args.time_in_force:
+        payload["timeInForce"] = args.time_in_force
+    if args.recv_window is not None:
+        payload["recvWindow"] = args.recv_window
+    payload.update(parse_extra_arguments(args.extra))
+
+    data = request("POST", url, json_payload=payload)
+    print(json.dumps(data, indent=2, sort_keys=True))
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Construct the CLI argument parser.
+
+    创建并配置客户端所需的命令行参数解析器，包含查询账户、保证持仓和直接
+    下单等子命令的参数说明。"""
+    parser = argparse.ArgumentParser(description="Client for the Aster trading gateway")
+    parser.add_argument("--server", default=DEFAULT_SERVER, help="Base URL of the trading server")
+
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    account_parser = subparsers.add_parser("account", help="Fetch balances and open positions")
+    account_parser.set_defaults(func=handle_account)
+
+    ensure_parser = subparsers.add_parser(
+        "ensure-position", help="Ensure an open position exists; place an order if not"
+    )
+    ensure_parser.add_argument("symbol", help="Trading symbol, e.g. BTCUSDT")
+    ensure_parser.add_argument("side", help="Order side (BUY or SELL)")
+    ensure_parser.add_argument("quantity", type=float, help="Order quantity")
+    ensure_parser.add_argument("--type", default="MARKET", help="Order type (default: MARKET)")
+    ensure_parser.add_argument("--price", type=float, help="Limit price")
+    ensure_parser.add_argument("--time-in-force", dest="time_in_force", help="Time in force policy")
+    ensure_parser.add_argument("--recv-window", dest="recv_window", type=int, help="Custom recvWindow")
+    ensure_parser.add_argument(
+        "--extra",
+        nargs="*",
+        default=[],
+        help="Additional key=value pairs forwarded to the API",
+    )
+    ensure_parser.set_defaults(func=handle_ensure_position)
+
+    order_parser = subparsers.add_parser("order", help="Submit a raw order payload")
+    order_parser.add_argument("symbol", help="Trading symbol, e.g. BTCUSDT")
+    order_parser.add_argument("side", help="Order side (BUY or SELL)")
+    order_parser.add_argument("type", help="Order type, e.g. MARKET or LIMIT")
+    order_parser.add_argument("quantity", type=float, help="Order quantity")
+    order_parser.add_argument("--price", type=float, help="Limit price")
+    order_parser.add_argument("--time-in-force", dest="time_in_force", help="Time in force policy")
+    order_parser.add_argument("--reduce-only", dest="reduce_only", action="store_true")
+    order_parser.add_argument("--no-reduce-only", dest="reduce_only", action="store_false")
+    order_parser.set_defaults(reduce_only=None)
+    order_parser.add_argument("--client-order-id", dest="client_order_id", help="Client order identifier")
+    order_parser.add_argument("--recv-window", dest="recv_window", type=int, help="Custom recvWindow")
+    order_parser.add_argument(
+        "--extra",
+        nargs="*",
+        default=[],
+        help="Additional key=value pairs forwarded to the API",
+    )
+    order_parser.set_defaults(func=handle_order)
+
+    return parser
+
+
+def main() -> None:
+    """Entrypoint for the CLI client.
+
+    解析命令行参数后执行对应子命令，并在请求或参数错误时输出提示信息，
+    以便用户快速定位问题。"""
+    parser = build_parser()
+    args = parser.parse_args()
+    try:
+        args.func(args)
+    except ValueError as error:
+        print(error)
+        raise SystemExit(1) from error
+    except httpx.HTTPError as error:
+        print(f"Request failed: {error}")
+        raise SystemExit(1) from error
+
+
+if __name__ == "__main__":
+    main()
+

--- a/examples/trading_app/requirements.txt
+++ b/examples/trading_app/requirements.txt
@@ -1,0 +1,4 @@
+fastapi>=0.110
+uvicorn[standard]>=0.23
+httpx>=0.24
+python-dotenv>=1.0

--- a/examples/trading_app/server.py
+++ b/examples/trading_app/server.py
@@ -1,0 +1,186 @@
+"""FastAPI trading service for running on a Google Cloud VM.
+
+这个模块提供一个可以部署到 Google Cloud 虚拟机上的 FastAPI 交易服务，
+用于暴露账户余额、持仓信息以及下单接口，供本地客户端通过网络调用。"""
+from __future__ import annotations
+
+import os
+from functools import lru_cache
+from typing import Any, Dict, List, Optional
+
+from dotenv import load_dotenv
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+
+from aster.error import ClientError
+from aster.rest_api import Client
+
+load_dotenv()
+
+
+def _env(name: str) -> str:
+    """Fetch required environment variables.
+
+    获取启动交易服务所需的环境变量，并在缺失时抛出异常，确保服务运行时
+    一定拥有访问 Aster API 所需的密钥。"""
+    value = os.getenv(name)
+    if not value:
+        raise RuntimeError(f"Environment variable {name} is required to start the trading service.")
+    return value
+
+
+@lru_cache()
+def get_client() -> Client:
+    """Return a cached API client configured with environment credentials.
+
+    返回一个使用环境变量中凭证初始化的 Aster API 客户端，并通过 LRU 缓存
+    避免重复创建实例，从而提升请求处理效率。"""
+    return Client(key=_env("ASTER_API_KEY"), secret=_env("ASTER_API_SECRET"))
+
+
+class AccountOverview(BaseModel):
+    balances: List[Dict[str, Any]]
+    positions: List[Dict[str, Any]]
+    has_open_positions: bool
+
+
+class OrderRequest(BaseModel):
+    symbol: str
+    side: str
+    type: str = "MARKET"
+    quantity: float
+    price: Optional[float] = None
+    timeInForce: Optional[str] = None
+    reduceOnly: Optional[bool] = None
+    newClientOrderId: Optional[str] = None
+    recvWindow: Optional[int] = None
+
+    class Config:
+        extra = "allow"
+
+    def to_api_params(self) -> Dict[str, Any]:
+        """Convert the request to API parameters.
+
+        将请求模型转换成去除空值后的字典，直接用于调用 Aster 下单接口。"""
+        return self.dict(exclude_none=True)
+
+
+class EnsurePositionRequest(OrderRequest):
+    """Ensure that a position exists for the requested symbol.
+
+    请求体在标准下单参数的基础上，明确表示调用者希望目标交易对存在持仓；
+    如若没有持仓，将自动下单建立新仓位。"""
+
+
+class EnsurePositionResponse(BaseModel):
+    has_position: bool
+    position: Optional[Dict[str, Any]] = None
+    order_placed: bool = False
+    order_response: Optional[Dict[str, Any]] = None
+
+
+app = FastAPI(title="Aster Trading Gateway", version="1.0.0")
+
+
+def _has_open_position(positions: List[Dict[str, Any]], symbol: Optional[str] = None) -> Optional[Dict[str, Any]]:
+    """Determine whether there is an open position for the optional symbol.
+
+    遍历账户持仓列表，支持按照指定交易对筛选；若存在数量不为零的持仓，
+    则返回对应的持仓信息，否则返回 ``None``。"""
+    for position in positions:
+        if symbol and position.get("symbol") != symbol:
+            continue
+        try:
+            quantity = float(position.get("positionAmt", 0))
+        except (TypeError, ValueError):
+            quantity = 0
+        if abs(quantity) > 0:
+            return position
+    return None
+
+
+def _handle_client_error(error: ClientError) -> HTTPException:
+    """Convert an SDK ClientError into an HTTPException.
+
+    将 Aster SDK 抛出的 ``ClientError`` 转换成 FastAPI 友好的 ``HTTPException``，
+    并保留服务端返回的错误明细，方便客户端定位问题。"""
+    detail = {
+        "code": error.error_code,
+        "message": error.error_message,
+        "status_code": error.status_code,
+        "header": error.header,
+    }
+    return HTTPException(status_code=error.status_code or 400, detail=detail)
+
+
+@app.get("/account", response_model=AccountOverview)
+def account_overview() -> AccountOverview:
+    """Return account balances and open positions.
+
+    查询账户当前余额及持仓列表，同时判断是否存在任意非零持仓，结果将
+    作为统一结构返回给客户端。"""
+    client = get_client()
+    try:
+        balances = client.balance()
+        positions = client.get_position_risk()
+    except ClientError as error:
+        raise _handle_client_error(error) from error
+
+    open_position = _has_open_position(positions)
+    return AccountOverview(
+        balances=balances,
+        positions=positions,
+        has_open_positions=open_position is not None,
+    )
+
+
+@app.post("/orders")
+def create_order(order: OrderRequest) -> Dict[str, Any]:
+    """Forward an order creation request to the exchange.
+
+    将客户端提交的下单参数转发到 Aster 交易所，并返回原始响应结果。"""
+    client = get_client()
+    payload = order.to_api_params()
+    try:
+        response = client.new_order(**payload)
+    except ClientError as error:
+        raise _handle_client_error(error) from error
+    return {"order": response}
+
+
+@app.post("/ensure-position", response_model=EnsurePositionResponse)
+def ensure_position(request: EnsurePositionRequest) -> EnsurePositionResponse:
+    """Ensure a position exists for the symbol, placing an order if required.
+
+    首先检查目标交易对是否已有持仓；若没有，则使用请求参数补建仓位，
+    并将执行结果反馈给调用方。"""
+    client = get_client()
+    try:
+        positions = client.get_position_risk()
+    except ClientError as error:
+        raise _handle_client_error(error) from error
+
+    position = _has_open_position(positions, symbol=request.symbol)
+    if position:
+        return EnsurePositionResponse(has_position=True, position=position)
+
+    payload = request.to_api_params()
+    try:
+        order_response = client.new_order(**payload)
+    except ClientError as error:
+        raise _handle_client_error(error) from error
+
+    return EnsurePositionResponse(
+        has_position=False,
+        order_placed=True,
+        order_response=order_response,
+    )
+
+
+@app.get("/ping")
+def ping() -> Dict[str, str]:
+    """Simple health check endpoint.
+
+    提供一个最简单的连通性检测接口，便于部署后确认服务是否存活。"""
+    return {"status": "ok"}
+


### PR DESCRIPTION
## Summary
- add a Chinese README that introduces the project and cloud trading example
- extend the trading app example README with a full Chinese usage guide
- document each trading module with bilingual docstrings and link to the Chinese docs from the main README

## Testing
- python -m compileall examples/trading_app

------
https://chatgpt.com/codex/tasks/task_e_68df970ce6808329b794418179758f5f